### PR TITLE
Fix for errors in IE on SSL connections

### DIFF
--- a/lib/csv_builder/template_handler.rb
+++ b/lib/csv_builder/template_handler.rb
@@ -96,9 +96,9 @@ module CsvBuilder # :nodoc:
         unless defined?(ActionMailer) && defined?(ActionMailer::Base) && controller.is_a?(ActionMailer::Base)
           @filename ||= "\#{controller.action_name}.csv"
           if controller.request.env['HTTP_USER_AGENT'] =~ /msie/i
-            response.headers['Pragma'] = 'public'
+            response.headers['Pragma'] = 'must-revalidate'
             response.headers["Content-type"] = "text/plain"
-            response.headers['Cache-Control'] = 'no-cache, must-revalidate, post-check=0, pre-check=0'
+            response.headers['Cache-Control'] = 'must-revalidate, post-check=0, pre-check=0'
             response.headers['Content-Disposition'] = "attachment; filename=\#{@filename}"
             response.headers['Expires'] = "0"
           else


### PR DESCRIPTION
If you include no-cache in the headers to IE over an SSL connection, IE refuses to save the file to disk. In its current state, it is not possible to use csv_builder to send CSVs to IE over SSL.

This commit tones down the IE headers a bit, which fixes the problem.

Additional info on the issue:

http://support.microsoft.com/kb/323308
http://stackoverflow.com/questions/3415370/ie-unable-to-download-from-unable-to-open-this-internet-site-the-request
