### PR TITLE
Fixed content-disposition error that occurs with filename set and new chrome version

### DIFF
--- a/lib/csv_builder/template_handler.rb
+++ b/lib/csv_builder/template_handler.rb
@@ -99,11 +99,11 @@ module CsvBuilder # :nodoc:
             response.headers['Pragma'] = 'public'
             response.headers["Content-type"] = "text/plain"
             response.headers['Cache-Control'] = 'no-cache, must-revalidate, post-check=0, pre-check=0'
-            response.headers['Content-Disposition'] = "attachment; filename=\"\#{@filename}\""
+            response.headers['Content-Disposition'] = "attachment; filename=\\"\#{@filename}\\""
             response.headers['Expires'] = "0"
           else
             response.headers["Content-Type"] ||= 'text/csv'
-            response.headers["Content-Disposition"] = "attachment; filename=\"\#{@filename}\""
+            response.headers["Content-Disposition"] = "attachment; filename=\\"\#{@filename}\\""
             response.headers["Content-Transfer-Encoding"] = "binary"
           end
         end


### PR DESCRIPTION
We have an issue in chrome with filename containing spaces :

```
Error 349 (net::ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION): Multiple
Content-Disposition headers received. This is disallowed to protect against HTTP
response splitting attacks
```
