### PR TITLE
Add: Support for Rails 6

### DIFF
--- a/lib/csv_builder/template_handler.rb
+++ b/lib/csv_builder/template_handler.rb
@@ -88,7 +88,8 @@ module CsvBuilder # :nodoc:
   end
 
   class TemplateHandler
-    def self.call(template)
+    def self.call(template, source = nil)
+      source ||= template.source
 
       <<-EOV
       begin
@@ -110,13 +111,13 @@ module CsvBuilder # :nodoc:
 
         if @streaming
           template = Proc.new {|csv|
-            #{template.source}
+            #{source}
           }
           CsvBuilder::Streamer.new(template)
         else
           output = CsvBuilder::CSV_LIB.generate(@csv_options || {}) do |faster_csv|
             csv = CsvBuilder::TransliteratingFilter.new(faster_csv, @input_encoding || 'UTF-8', @output_encoding || 'ISO-8859-1')
-            #{template.source}
+            #{source}
           end
           output
         end


### PR DESCRIPTION
Rails 6 deprecates single-arity template handlers. This changes the
template handler to take the template source as a second parameter and
use that throughout.

@gtd please take a look at this.