### PR TITLE
Avoid Ruby 2.7/3.0 deprecation warning

### DIFF
--- a/lib/csv_builder/template_handler.rb
+++ b/lib/csv_builder/template_handler.rb
@@ -115,7 +115,7 @@ module CsvBuilder # :nodoc:
           }
           CsvBuilder::Streamer.new(template)
         else
-          output = CsvBuilder::CSV_LIB.generate(@csv_options || {}) do |faster_csv|
+          output = CsvBuilder::CSV_LIB.generate(**(@csv_options || {})) do |faster_csv|
             csv = CsvBuilder::TransliteratingFilter.new(faster_csv, @input_encoding || 'UTF-8', @output_encoding || 'ISO-8859-1')
             #{source}
           end


### PR DESCRIPTION
Double asterisks, `**`, in the method definition of `generate` require double asterisks in the method call to convert a hash to splashed keyword arguments.

Missing asterisks in the call give a warning in Ruby 2.7 and will fail in Ruby 3.0.